### PR TITLE
display map crosshair during export

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ map.addControl(new MapboxExportControl({
     PageOrientation: PageOrientation.Portrait,
     Format: Format.PNG,
     DPI: DPI[96],
+    Crosshair: true
 }), 'top-right');
 ```
 
@@ -62,6 +63,10 @@ You can specify default option as follows.
 - DPI
   - You can select it from `72`, `96`, `200`, `300` and `400`.
   - default is `300`
+- Crosshair
+  - Display crosshair on the map. it helps to adjust the map center before printing.
+  - accepts true and false value
+  - default is false
 
 ## Attribution
 

--- a/lib/crosshair-manager.ts
+++ b/lib/crosshair-manager.ts
@@ -1,0 +1,112 @@
+import { Map as MapboxMap } from "mapbox-gl";
+
+export default class CrosshairManager {
+    private width: number | undefined;
+    private height: number | undefined;
+    private svgCanvas: SVGElement | undefined;
+    private xLine: SVGElement | undefined;
+    private yLine: SVGElement | undefined;
+    private color = '#535353';
+
+    constructor(
+        private map: MapboxMap | undefined
+    ) {
+    }
+
+    public create() {
+        this.updateValues();
+        if (this.map !== undefined) {
+            this.map.on('resize', this.mapResize.bind(this));
+            this.createCanvas(this.map.getCanvasContainer());
+        } else {
+            console.error('map object is null');
+        }
+
+    }
+
+    private updateValues() {
+        this.width = this.map?.getCanvas().clientWidth;
+        this.height = this.map?.getCanvas().clientHeight;
+    }
+
+    private mapResize(evt) {
+        this.updateValues();
+        this.updateCanvas();
+    }
+
+    private updateCanvas() {
+        if (
+            this.svgCanvas !== undefined &&
+            this.yLine !== undefined &&
+            this.xLine !== undefined &&
+            this.width !== undefined &&
+            this.height !== undefined) {
+            this.svgCanvas.setAttribute('width', `${this.width}px`);
+            this.svgCanvas.setAttribute('height', `${this.height}px`);
+            const halfWidth = this.width / 2;
+            const halfHeight = this.height / 2;
+            this.yLine.setAttribute('x1', `${halfWidth}px`);
+            this.yLine.setAttribute('y1', `0px`);
+            this.yLine.setAttribute('x2', `${halfWidth}px`);
+            this.yLine.setAttribute('y2', `${this.height}px`);
+
+            this.xLine.setAttribute('x1', `${0}px`);
+            this.xLine.setAttribute('y1', `${halfHeight}px`);
+            this.xLine.setAttribute('x2', `${this.width}px`);
+            this.xLine.setAttribute('y2', `${halfHeight}px`);
+        } else {
+            console.error('element value is null');
+        }
+
+    }
+
+    private createCanvas(container) {
+        if (
+            this.width !== undefined &&
+            this.height !== undefined) {
+            var canvas = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+            canvas.style.position = 'relative';
+            canvas.setAttribute('width', `${this.width}px`);
+            canvas.setAttribute('height', `${this.height}px`);
+            const halfWidth = this.width / 2;
+            const halfHeight = this.height / 2;
+            this.yLine = canvas.appendChild(this.createLine(halfWidth, 0, halfWidth, this.height, this.color, '2px'));
+            this.xLine = canvas.appendChild(this.createLine(0, halfHeight, this.width, halfHeight, this.color, '2px'));
+            container?.appendChild(canvas);
+            this.svgCanvas = canvas;
+        }
+    }
+    private createLine(x1, y1, x2, y2, color, w) {
+        var aLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        aLine.setAttribute('x1', x1);
+        aLine.setAttribute('y1', y1);
+        aLine.setAttribute('x2', x2);
+        aLine.setAttribute('y2', y2);
+        aLine.setAttribute('stroke-dasharray', '5,5');
+        aLine.setAttribute('stroke', color);
+        aLine.setAttribute('stroke-width', w);
+        return aLine;
+    }
+
+    public destroy() {
+        if (this.xLine !== undefined) {
+            this.xLine.remove();
+            this.xLine = undefined;
+        }
+
+        if (this.yLine !== undefined) {
+            this.yLine.remove();
+            this.yLine = undefined;
+        }
+
+        if (this.svgCanvas !== undefined) {
+            this.svgCanvas.remove();
+            this.svgCanvas = undefined;
+        }
+
+        if (this.map !== undefined) {
+            this.map.off('resize', this.mapResize);
+            this.map = undefined;
+        }
+    }
+}

--- a/lib/export-control.ts
+++ b/lib/export-control.ts
@@ -167,7 +167,6 @@ export default class MapboxExportControl implements IControl
     }
 
     private onDocumentClick(event: MouseEvent): void{
-      console.log('onDocumentClick');
       if (this.controlContainer && !this.controlContainer.contains(event.target as Element) && this.exportContainer && this.exportButton) {
         this.exportContainer.style.display = "none";
         this.exportButton.style.display = "block";

--- a/lib/export-control.ts
+++ b/lib/export-control.ts
@@ -1,4 +1,5 @@
 import { IControl, Map as MapboxMap } from "mapbox-gl";
+import CrosshairManager from "./crosshair-manager";
 import { default as MapGenerator, Size, Format, PageOrientation, DPI, Unit } from './map-generator'
 
 type Options = {
@@ -6,6 +7,7 @@ type Options = {
   PageOrientation: string;
   Format: string;
   DPI: number;
+  Crosshair?: boolean;
 }
 
 /**
@@ -17,6 +19,7 @@ export default class MapboxExportControl implements IControl
 
     private controlContainer: HTMLElement;
     private exportContainer: HTMLElement;
+    private crosshair: CrosshairManager | undefined;
     private map?: MapboxMap;
     private exportButton: HTMLButtonElement;
 
@@ -25,6 +28,7 @@ export default class MapboxExportControl implements IControl
       PageOrientation: PageOrientation.Landscape,
       Format: Format.PDF,
       DPI: DPI[300],
+      Crosshair: false,
     }
 
     constructor(options: Options)
@@ -88,7 +92,7 @@ export default class MapboxExportControl implements IControl
         table.appendChild(tr4);
 
         this.exportContainer.appendChild(table)
-        
+
         const generateButton = document.createElement("button");
         generateButton.textContent = 'Generate';
         generateButton.classList.add('generate-button');
@@ -152,13 +156,31 @@ export default class MapboxExportControl implements IControl
       this.exportButton.removeEventListener("click", this.onDocumentClick);
       this.controlContainer.parentNode.removeChild(this.controlContainer);
       document.removeEventListener("click", this.onDocumentClick);
+
+
+      if (this.crosshair !== undefined) {
+        this.crosshair.destroy();
+        this.crosshair = undefined;
+      }
+
       this.map = undefined;
     }
 
     private onDocumentClick(event: MouseEvent): void{
+      console.log('onDocumentClick');
       if (this.controlContainer && !this.controlContainer.contains(event.target as Element) && this.exportContainer && this.exportButton) {
         this.exportContainer.style.display = "none";
         this.exportButton.style.display = "block";
+
+        if (this.crosshair !== undefined) {
+          this.crosshair.destroy();
+          this.crosshair = undefined;
+        }
+      } else {
+        if (this.options.Crosshair === true) {
+          this.crosshair = new CrosshairManager(this.map);
+          this.crosshair.create();
+        }
       }
     }
 }


### PR DESCRIPTION
 Displaying crosshair helps to center the map, before exporting the map.

![export-crosshair_optimized](https://user-images.githubusercontent.com/1282742/111921177-886d5d80-8a69-11eb-87ba-31fa0111c54f.gif)

- display crosshair only when the export options are visible on the screen.
- Options type is extended to include crosshair boolean parameter to provide the ability to optin to this feature or not
- right now i set the crosshair off by default and optional.. to preserve backward compatability 