### PR TITLE
Fix form submit button issue

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -14,6 +14,7 @@
     text-align: right;
     width: 100%;
     height: auto;
+    text-align: center;
 }
 
 .mapboxgl-export-list button.active

--- a/lib/export-control.ts
+++ b/lib/export-control.ts
@@ -57,6 +57,7 @@ export default class MapboxExportControl implements IControl {
       this.exportButton = document.createElement('button');
       this.exportButton.classList.add('mapboxgl-ctrl-icon');
       this.exportButton.classList.add('mapboxgl-export-control');
+      this.exportButton.type = 'button';
       this.exportButton.addEventListener('click', () => {
         this.exportButton.style.display = 'none';
         this.exportContainer.style.display = 'block';
@@ -92,6 +93,7 @@ export default class MapboxExportControl implements IControl {
       this.exportContainer.appendChild(table);
 
       const generateButton = document.createElement('button');
+      generateButton.type = 'button';
       generateButton.textContent = 'Generate';
       generateButton.classList.add('generate-button');
       generateButton.addEventListener('click', () => {


### PR DESCRIPTION
When the map is placed inside a form the exportButton and generateButton act as submit button because by default the button type is 'submit'.

Set the button type to 'button' so it will act as a regular button.