### PR TITLE
fix binding issue with crosshair-manager

### DIFF
--- a/lib/crosshair-manager.ts
+++ b/lib/crosshair-manager.ts
@@ -19,7 +19,7 @@ export default class CrosshairManager {
       map: MapboxMap | undefined,
     ) {
       this.map = map;
-      this.mapResize = this.mapResize.bind(this)
+      this.mapResize = this.mapResize.bind(this);
     }
 
     public create() {


### PR DESCRIPTION
Hi,

I have found an issue with the `mapResize` method from the CrosshairManager.

if I export a map and for the second time I click again on the print button and resize the browser. the 'resize' map event was not correctly unregistered and I encounter an error

## Description

You register the mapResize.bind(this) for the 'resize' map event but you unregister the 'resize' map event with only the mapResize , which is not the same method .

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `npm run lint`
- [x] Make sure all the exsiting features working well
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/mapbox-gl-export/tree/master/.github/CONTRIBUTING.md) for more details.
