### PR TITLE
fixes: printable area was broke when resize map

### DIFF
--- a/lib/printable-area-manager.ts
+++ b/lib/printable-area-manager.ts
@@ -23,6 +23,8 @@ export default class PrintableAreaManager {
       if (this.map === undefined) {
         return;
       }
+      this.mapResize = this.mapResize.bind(this);
+      this.map.on('resize', this.mapResize);
       const clientWidth = this.map?.getCanvas().clientWidth;
       const clientHeight = this.map?.getCanvas().clientHeight;
       const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
@@ -38,6 +40,10 @@ export default class PrintableAreaManager {
       this.map?.getCanvasContainer().appendChild(svg);
       this.svgCanvas = svg;
       this.svgPath = path;
+    }
+
+    private mapResize() {
+      this.generateCutOut();
     }
 
     public updateArea(width: number, height: number) {


### PR DESCRIPTION
## Description

fixes: printable area was broke when resize map

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `npm run lint`
- [x] Make sure all the exsiting features working well
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/mapbox-gl-export/tree/master/.github/CONTRIBUTING.md) for more details.
